### PR TITLE
✨ feat(make-action): add artisan command to scaffold Actions

### DIFF
--- a/app/Console/Commands/MakeActionCommand.php
+++ b/app/Console/Commands/MakeActionCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+final class MakeActionCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new action';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/action.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return base_path($stub);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\\Actions';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the action even if the action already exists'],
+        ];
+    }
+}

--- a/stubs/action.stub
+++ b/stubs/action.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    /**
+     * Handle the action.
+     */
+    public function handle()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Introduce a MakeActionCommand that generates Action classes from a
simple stub. The command is registered as make:action and uses a custom
stub path resolution so stubs can live in the project's stubs folder.
It places generated classes under the Actions namespace and supports a
--force/-f option to overwrite existing files.

This adds:
- app/Console/Commands/MakeActionCommand.php implementing the generator.
- stubs/action.stub as the template for new Action classes.

Motivation: streamline creation of Action classes and enforce a
conventional Actions namespace for new scaffolding.